### PR TITLE
fix(dashboard): Update CloudWatch Dashboard

### DIFF
--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -49,7 +49,7 @@
                         "AWS/SNS",
                         "NumberOfMessagesPublished",
                         "TopicName",
-                        "Alerts-base-alerts-${sls:stage}"
+                        "Alerts-seatool-alerts-${sls:stage}"
                     ]
                 ],
                 "view": "timeSeries",

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -39,10 +39,10 @@
         },
         {
             "type": "metric",
-            "x": 0,
-            "y": 4,
             "width": 8,
             "height": 8,
+            "x": 0,
+            "y": 4,
             "properties": {
                 "metrics": [
                     [
@@ -58,6 +58,235 @@
                 "title": "SNS Topic",
                 "period": 60,
                 "stat": "Sum"
+            }
+        },
+ {
+            "height": 1,
+            "width": 24,
+            "y": 12,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "## connector service",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 8,
+            "width": 8,
+            "y": 13,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [
+                        "AWS/ECS",
+                        "CPUUtilization",
+                        "ServiceName",
+                        "kafka-connect",
+                        "ClusterName",
+                        "seatool-connectors-${sls:stage}-connect",
+                        {
+                            "color": "#ff7f0e"
+                        }
+                    ],
+                    [
+                        ".",
+                        "MemoryUtilization",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        {
+                            "color": "#1f77b4"
+                        }
+                    ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${env:REGION_A}",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "max": 100,
+                        "min": 0
+                    }
+                },
+                "title": "Connector CPU and Memory Utilization",
+                "stat": "Average"
+            }
+        },
+        {
+            "height": 5,
+            "width": 24,
+            "y": 21,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/fargate/seatool-connectors-${sls:stage}-kafka-connect' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "region": "${env:REGION_A}",
+                "stacked": false,
+                "title": "Connector ECS Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "view": "table"
+            }
+        },
+        {
+            "height": 8,
+            "width": 6,
+            "y": 13,
+            "x": 16,
+            "type": "alarm",
+            "properties": {
+                "title": "Connector Alarms",
+                "alarms": [
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-JdbcTaskAlarm-1CQOFNLUKS7KV",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-JdbcConnectorAlarm-WL4ZMADV64NE",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-ConnectorLogsErrorCount",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-KafkaConnectService-CPUUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-KafkaConnectService-MemoryUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-ConnectorLogsWarnCount"
+                ]
+            }
+        },
+        {
+            "height": 8,
+            "width": 8,
+            "y": 13,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [
+                        "AWS/Lambda",
+                        "Invocations",
+                        "FunctionName",
+                        "seatool-connectors-${sls:stage}-configureConnectors"
+                    ],
+                    [
+                        ".",
+                        "Errors",
+                        ".",
+                        "."
+                    ]
+                ],
+                "region": "${env:REGION_A}",
+                "title": "ConfigureConnectors Lambda"
+            }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 26,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "## ksqldb service",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 5,
+            "width": 24,
+            "y": 35,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/fargate/seatool-ksqldb-${sls:stage}-ksqldb-headless' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "region": "${env:REGION_A}",
+                "stacked": false,
+                "title": "KSQLDB Headless Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "view": "table"
+            }
+        },
+        {
+            "height": 8,
+            "width": 8,
+            "y": 27,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [
+                        "AWS/ECS",
+                        "CPUUtilization",
+                        "ServiceName",
+                        "ksqldb-headless",
+                        "ClusterName",
+                        "seatool-ksqldb-${sls:stage}-connect",
+                        {
+                            "color": "#ff7f0e"
+                        }
+                    ],
+                    [
+                        ".",
+                        "MemoryUtilization",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        {
+                            "color": "#1f77b4"
+                        }
+                    ],
+                    [
+                        "...",
+                        "ksqldb-interactive",
+                        ".",
+                        "."
+                    ],
+                    [
+                        ".",
+                        "CPUUtilization",
+                        ".",
+                        ".",
+                        ".",
+                        "."
+                    ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${env:REGION_A}",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "max": 100,
+                        "min": 0
+                    }
+                },
+                "title": "KSQLDB ECS CPU and Memory Utilization",
+                "stat": "Average"
+            }
+        },
+        {
+            "height": 8,
+            "width": 6,
+            "y": 27,
+            "x": 8,
+            "type": "alarm",
+            "properties": {
+                "title": "KSQLDB Alarms",
+                "alarms": [
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-ksqldb-${sls:stage}-ksqldbHeadlessService-CPUUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-ksqldb-${sls:stage}-ksqldbHeadlessService-MemoryUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-ksqldb-${sls:stage}-ksqldbIntService-CPUUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-ksqldb-${sls:stage}-ksqldbIntService-MemoryUtilization"
+                ]
+            }
+        },
+        {
+            "height": 5,
+            "width": 24,
+            "y": 40,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/fargate/seatool-ksqldb-${sls:stage}-ksqldbInt' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "region": "${env:REGION_A}",
+                "stacked": false,
+                "title": "KSQLDB Interactive Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "view": "table"
             }
         }
     ]

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -85,7 +85,7 @@
                         "ServiceName",
                         "kafka-connect",
                         "ClusterName",
-                        "seatool-connectors-${sls:stage}-connect",
+                        "seatool-connector-${sls:stage}-connect",
                         {
                             "color": "#ff7f0e"
                         }
@@ -123,10 +123,10 @@
             "x": 0,
             "type": "log",
             "properties": {
-                "query": "SOURCE '/aws/fargate/seatool-connectors-${sls:stage}-kafka-connect' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "query": "SOURCE '/aws/fargate/seatool-connector-${sls:stage}-kafka-connect' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
                 "region": "${env:REGION_A}",
                 "stacked": false,
-                "title": "Connector ECS Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "title": "Connector ECS Logs: /aws/fargate/seatool-connector-${sls:stage}-kafka-connect",
                 "view": "table"
             }
         },
@@ -139,12 +139,12 @@
             "properties": {
                 "title": "Connector Alarms",
                 "alarms": [
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-JdbcTaskAlarm-1CQOFNLUKS7KV",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-JdbcConnectorAlarm-WL4ZMADV64NE",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-ConnectorLogsErrorCount",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-KafkaConnectService-CPUUtilization",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-KafkaConnectService-MemoryUtilization",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connectors-${sls:stage}-ConnectorLogsWarnCount"
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-JdbcTaskAlarm-1CQOFNLUKS7KV",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-JdbcConnectorAlarm-WL4ZMADV64NE",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-ConnectorLogsErrorCount",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-KafkaConnectService-CPUUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-KafkaConnectService-MemoryUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:seatool-connector-${sls:stage}-ConnectorLogsWarnCount"
                 ]
             }
         },
@@ -162,7 +162,7 @@
                         "AWS/Lambda",
                         "Invocations",
                         "FunctionName",
-                        "seatool-connectors-${sls:stage}-configureConnectors"
+                        "seatool-connector-${sls:stage}-configureConnectors"
                     ],
                     [
                         ".",
@@ -196,7 +196,7 @@
                 "query": "SOURCE '/aws/fargate/seatool-ksqldb-${sls:stage}-ksqldb-headless' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
                 "region": "${env:REGION_A}",
                 "stacked": false,
-                "title": "KSQLDB Headless Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "title": "KSQLDB Headless Logs: /aws/fargate/seatool-connector-${sls:stage}-kafka-connect",
                 "view": "table"
             }
         },
@@ -285,7 +285,7 @@
                 "query": "SOURCE '/aws/fargate/seatool-ksqldb-${sls:stage}-ksqldbInt' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
                 "region": "${env:REGION_A}",
                 "stacked": false,
-                "title": "KSQLDB Interactive Logs: /aws/fargate/seatool-connectors-${sls:stage}-kafka-connect",
+                "title": "KSQLDB Interactive Logs: /aws/fargate/seatool-connector-${sls:stage}-kafka-connect",
                 "view": "table"
             }
         }


### PR DESCRIPTION
## Purpose
Followed Mike's logic to update the CloudWatch dashboard to correctly track application health.

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23588

## Approach

The CloudWatch dashboard was updated by configuring the dashboard in the UI to match mmdl-connectors, running the template export widget from the dashboard, and checking in the source it output.

## Assorted Notes/Considerations/Learning

You can check it out (as long as this PR/branch is up) at https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=seatool-dashboard-dashboard

Screenshots:
![Screen Shot 2023-04-05 at 8 38 51 AM](https://user-images.githubusercontent.com/55826377/230132182-32c78129-ba76-444a-9149-ebbd9107eeac.png)


![Screen Shot 2023-04-05 at 8 39 00 AM](https://user-images.githubusercontent.com/55826377/230132196-f24e38eb-b826-4c16-ae74-6401e55bfc32.png)

![Screen Shot 2023-04-05 at 8 39 06 AM](https://user-images.githubusercontent.com/55826377/230132218-8b9aeb82-05c2-44f0-b4fc-83dcb8f37468.png)
