### PR TITLE
fix(Ksql): Fix NULL records

### DIFF
--- a/src/services/ksqldb/ddl/seatool/k_sp_parent.sql
+++ b/src/services/ksqldb/ddl/seatool/k_sp_parent.sql
@@ -109,23 +109,26 @@ CREATE TABLE IF NOT EXISTS K_seatool_agg_OCD_Review
  GROUP BY sp.ID_Number
 EMIT CHANGES;
 
-
 CREATE TABLE IF NOT EXISTS K_seatool_tld_SP_Officers
  WITH (KAFKA_TOPIC='${param:topicNamespace}aws.ksqldb.seatool.tld.SP_Officers',KEY_FORMAT='JSON',WRAP_SINGLE_VALUE=FALSE) AS
- SELECT payload->after->ID_Number,
-        payload->after->RO_Analyst_ID,
-        payload->after->Backup_Program_Analyst_ID,
-        payload->after->Backup_FM_Analyst_ID,
-        payload->after->Lead_Analyst_ID,
+ SELECT payload->after->ID_Number ,
+        ifnull(payload->after->RO_Analyst_ID, -1) RO_Analyst_ID,
+        ifnull(payload->after->Backup_Program_Analyst_ID, -1) Backup_Program_Analyst_ID,
+        ifnull(payload->after->Backup_FM_Analyst_ID, -1) Backup_FM_Analyst_ID,
+        ifnull(payload->after->Lead_Analyst_ID, -1) Lead_Analyst_ID,
         STRUCT (
-         ID_Number := LATEST_BY_OFFSET(payload->after->ID_Number,FALSE),
-         RO_Analyst_ID := LATEST_BY_OFFSET(payload->after->RO_Analyst_ID,FALSE),
-         Backup_Program_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_Program_Analyst_ID,FALSE),
-         Backup_FM_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_FM_Analyst_ID,FALSE),
-         Lead_Analyst_ID := LATEST_BY_OFFSET(payload->after->Lead_Analyst_ID,FALSE)
-        ) SP_Officer
+          ID_Number := LATEST_BY_OFFSET(payload->after->ID_Number,FALSE),
+          RO_Analyst_ID := LATEST_BY_OFFSET(payload->after->RO_Analyst_ID,FALSE),
+          Backup_Program_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_Program_Analyst_ID,FALSE),
+          Backup_FM_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_FM_Analyst_ID,FALSE),
+          Lead_Analyst_ID := LATEST_BY_OFFSET(payload->after->Lead_Analyst_ID,FALSE)
+         ) SP_Officer
    FROM K_seatool_State_Plan_stream sp
- GROUP BY payload->after->ID_Number, payload->after->RO_Analyst_ID, payload->after->Backup_Program_Analyst_ID, payload->after->Backup_FM_Analyst_ID, payload->after->Lead_Analyst_ID
+ GROUP BY payload->after->ID_Number,
+       ifnull(payload->after->RO_Analyst_ID, -1),
+       ifnull(payload->after->Backup_Program_Analyst_ID, -1),
+       ifnull(payload->after->Backup_FM_Analyst_ID, -1),
+       ifnull(payload->after->Lead_Analyst_ID, -1)
 EMIT CHANGES;
 
 CREATE TABLE IF NOT EXISTS K_seatool_agg_RO_Analyst_Officers


### PR DESCRIPTION
**## Purpose**

Some of the data fields in the State_Plan table are not getting the correct literals. 

The data fields below are not getting rolled up to the State_Plan topic:
- "RO_ANALYST":null,
- "PROGRAM_ANALYST":null,
- "FM_ANALYST":null,
- "LEAD_ANALYST":null,

This PR will fix the KSQL script for the State_Plan table, the script will replace the NULL values for these columns with a value of -1.

**## Linked Issues to Close**
Ticket: https://qmacbis.atlassian.net/browse/OY2-23053

**## Approach**
KSQL "GROUP BY" on the columns is excluding any records with NULL values.

The KSQL script which creates K_seatool_tld_SP_Officers table was modified to replace NULL value with -1 for the above referenced columns.

---

SELECT payload->after->ID_Number ,
             ifnull(payload->after->RO_Analyst_ID, -1) RO_Analyst_ID,
             ifnull(payload->after->Backup_Program_Analyst_ID, -1) Backup_Program_Analyst_ID,
             ifnull(payload->after->Backup_FM_Analyst_ID, -1) Backup_FM_Analyst_ID,
             ifnull(payload->after->Lead_Analyst_ID, -1) Lead_Analyst_ID,
             STRUCT (
                            ID_Number := LATEST_BY_OFFSET(payload->after->ID_Number,FALSE),
                            RO_Analyst_ID := LATEST_BY_OFFSET(payload->after->RO_Analyst_ID,FALSE),
                            Backup_Program_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_Program_Analyst_ID,FALSE),
                            Backup_FM_Analyst_ID := LATEST_BY_OFFSET(payload->after->Backup_FM_Analyst_ID,FALSE),
                            Lead_Analyst_ID := LATEST_BY_OFFSET(payload->after->Lead_Analyst_ID,FALSE)
            ) SP_Officer
FROM K_seatool_State_Plan_stream sp
GROUP BY payload->after->ID_Number,
                  ifnull(payload->after->RO_Analyst_ID, -1),
                  ifnull(payload->after->Backup_Program_Analyst_ID, -1),
                  ifnull(payload->after->Backup_FM_Analyst_ID, -1),
                  ifnull(payload->after->Lead_Analyst_ID, -1)
EMIT CHANGES;

---

**## Assorted Notes/Considerations/Learning**

Check for any columns included in the “GROUP BY” have NULL values. If any columns have NULL values, replace them either 0 or -1 using the KSQL function **ifnull**.

**## List any other information that you think is important... a post-merge activity, someone to notify, what you learned, etc.**
N/A
