### PR TITLE
Add resources step in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,44 @@ jobs:
         with:
           input_path: cftemplates
 
+  resources:
+    runs-on: ubuntu-20.04
+    needs:
+      - deploy
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+          role-duration-seconds: 10800
+
+      - name: Get All Stage Resources
+        id: stage-resources
+        run: |
+          mkdir -p resources
+          resourceData=()
+          stackList=(`aws cloudformation describe-stacks --query "Stacks[?Tags[?Key=='STAGE' && Value=='$STAGE_NAME'] && Tags[?Key=='PROJECT' && Value=='$PROJECT']].StackName" --output text`)
+          for stack in "${stackList[@]}"; do
+            resources=$(aws cloudformation list-stack-resources --stack-name "$stack" --query "StackResourceSummaries[].{PhysicalResourceId:PhysicalResourceId, ResourceType:ResourceType, ResourceStatus:ResourceStatus, LogicalResourceId:LogicalResourceId, LastUpdatedTimestamp:LastUpdatedTimestamp}" --output json)
+            resourceData+=( $(echo "$resources" | jq -c --arg stack_name "$stack" '.[] + { StackName: $stack_name }') )
+          done
+          join_by() { local IFS="$1"; shift; echo "$*"; }
+          echo "["$(join_by "," "${resourceData[@]}")"]" > "resources/all_resources.json"
+
+      - name: Archive stage resources
+        uses: actions/upload-artifact@v3
+        with:
+          name: stage-resources
+          path: resources/all_resources.json
+
   release:
     runs-on: ubuntu-20.04
     needs:


### PR DESCRIPTION
## Purpose

this change adds a new workflow step to the project's Github Actions configuration that automatically collects all the resources from the CloudFormation stacks used in the project.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22399

## Approach

The new step uses the AWS CLI to iterate over all the stacks in the project and get all the resources from each of them. The resources are then put into a single array and saved to a file. This file is used to create a new artifact in Github Actions, which can be easily accessed and reviewed from the Actions screen.

This new workflow step helps to streamline the development process by automating the collection of CloudFormation resources, saving time and reducing errors. Additionally, the artifact created can be used to track changes to the resources over time, making it easier to troubleshoot and debug any issues that may arise.

## Assorted Notes/Considerations/Learning

this artifact might be able to be used in the docs web app, particularly in the deploy_metrics application. 
