### PR TITLE
fix(mssql-tools): update seatool-connectors sidecar to use mssql-tools

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -361,7 +361,7 @@ resources:
                 awslogs-stream-prefix: fargate
                 awslogs-datetime-format: \[%Y-%m-%d %H:%M:%S,
           - Name: instantclient
-            Image: "ghcr.io/oracle/oraclelinux8-instantclient:21"
+            Image: "mcr.microsoft.com/mssql-tools"
             Memory: 2048
             Command:
               - bash

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -81,8 +81,8 @@ custom:
           aws --region ${self:provider.region} ecs execute-command --cluster ${self:service}-${sls:stage}-connect --task ${task##*/} --container connect --interactive --command "/bin/sh"
           To connect to the connect-ui, run:
           aws --region ${self:provider.region} ecs execute-command --cluster ${self:service}-${sls:stage}-connect --task ${task##*/} --container connect-ui --interactive --command "/bin/sh"
-          To connect to the sql instantclient, run:
-          aws --region ${self:provider.region} ecs execute-command --cluster ${self:service}-${sls:stage}-connect --task ${task##*/} --container instantclient --interactive --command "/bin/sh"
+          To connect to the sql mssql-tools, run:
+          aws --region ${self:provider.region} ecs execute-command --cluster ${self:service}-${sls:stage}-connect --task ${task##*/} --container mssql-tools --interactive --command "/bin/sh"
           """
         done
 params:
@@ -360,7 +360,7 @@ resources:
                 awslogs-group: !Ref KafkaConnectWorkerLogGroup
                 awslogs-stream-prefix: fargate
                 awslogs-datetime-format: \[%Y-%m-%d %H:%M:%S,
-          - Name: instantclient
+          - Name: mssql-tools
             Image: "mcr.microsoft.com/mssql-tools"
             Memory: 2048
             Command:


### PR DESCRIPTION
## Purpose
Updated the run script to use an appropriate name (instantclient is Oracle specific), and update the image to pull the Microsoft image with the appropriate tooling (mcr.microsoft.com/mssql-tools).

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23850

## Approach
Changed the connect instaclient in oracle to mssql server. Changed the container name to mssql-tools

