### PR TITLE
Adjust SeaTool Metric Alarms to be less Sensitive

### DIFF
--- a/src/services/ksqldb/serverless.yml
+++ b/src/services/ksqldb/serverless.yml
@@ -451,8 +451,8 @@ resources:
           - Name: ServiceName
             Value: !GetAtt ksqldbHeadlessService.Name
         Statistic: Average
-        Period: 60
-        EvaluationPeriods: 5
+        Period: 300
+        EvaluationPeriods: 3
         Threshold: 80
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
@@ -493,8 +493,8 @@ resources:
           - Name: ServiceName
             Value: !GetAtt ksqldbIntService.Name
         Statistic: Average
-        Period: 60
-        EvaluationPeriods: 5
+        Period: 300
+        EvaluationPeriods: 3
         Threshold: 80
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:

--- a/src/services/ksqldb/serverless.yml
+++ b/src/services/ksqldb/serverless.yml
@@ -494,8 +494,8 @@ resources:
             Value: !GetAtt ksqldbIntService.Name
         Statistic: Average
         Period: 60
-        EvaluationPeriods: 2
-        Threshold: 75
+        EvaluationPeriods: 5
+        Threshold: 80
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}

--- a/src/services/ksqldb/serverless.yml
+++ b/src/services/ksqldb/serverless.yml
@@ -442,7 +442,7 @@ resources:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-ksqldbHeadlessService-CPUUtilization
-        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 80%"
         Namespace: AWS/ECS
         MetricName: CPUUtilization
         Dimensions:
@@ -452,8 +452,8 @@ resources:
             Value: !GetAtt ksqldbHeadlessService.Name
         Statistic: Average
         Period: 60
-        EvaluationPeriods: 2
-        Threshold: 75
+        EvaluationPeriods: 5
+        Threshold: 80
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
@@ -484,7 +484,7 @@ resources:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-ksqldbIntService-CPUUtilization
-        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 80%"
         Namespace: AWS/ECS
         MetricName: CPUUtilization
         Dimensions:


### PR DESCRIPTION
## Purpose

Currently we are in a perpetual state of alarm do in part to the spiky nature of ksqldb and how it handles work loads. The goal with this PR is to make both the sensitivity of ksql related alarms both less sensitive and also increase the threshold to something that makes more sense for ksql.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-24261

## Approach

Improve false-alarms being fired by both increasing the period of time it is checked and requiring more periods in alarm for it to trigger.